### PR TITLE
feat: support custom registry

### DIFF
--- a/agent.js
+++ b/agent.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = agent => {
+  agent.beforeStart(async function() {
+    // 可能不需要 sofaRegistry，比如直连的情况
+    if (!agent.sofaRegistry) return;
+
+    await agent.sofaRegistry.ready();
+  });
+};

--- a/app.js
+++ b/app.js
@@ -10,8 +10,14 @@ module.exports = app => {
     fieldClass: 'proxyClasses',
   });
 
-  const serverConfig = app.config.sofaRpc && app.config.sofaRpc.server;
-  if (serverConfig && serverConfig.namespace) {
+  const paths = app.loader.getLoadUnits().map(unit => path.join(unit.path, 'app/rpc'));
+  app.loader.loadToApp(paths, 'rpcServices', {
+    call: true,
+    caseStyle: 'camel', // 首字母不变
+  });
+
+  // 如果有 app/rpc 服务，则自动启动 server
+  if (Object.keys(app.rpcServices).length) {
     app.beforeStart(async function() {
       await app.sofaRpcServer.start();
     });

--- a/app/extend/agent.js
+++ b/app/extend/agent.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const _sofaRegistry = Symbol.for('egg#sofaRegistry');
+
+module.exports = {
+  get sofaRegistry() {
+    if (!this[_sofaRegistry]) {
+      const options = this.config.sofaRpc.registry;
+      if (!options) return null;
+      const registryClass = this.config.sofaRpc.registryClass;
+      this[_sofaRegistry] = new registryClass(Object.assign({
+        logger: this.coreLogger,
+        cluster: this.cluster,
+      }, options));
+      this[_sofaRegistry].on('error', err => { this.coreLogger.error(err); });
+      this.beforeClose(async () => {
+        await this[_sofaRegistry].close();
+      });
+    }
+    return this[_sofaRegistry];
+  },
+};

--- a/app/extend/application.js
+++ b/app/extend/application.js
@@ -3,7 +3,6 @@
 const EggRpcClient = require('../../lib/client');
 const EggRpcServer = require('../../lib/server');
 const ProxyBase = require('../../lib/base_proxy');
-const { ZookeeperRegistry } = require('sofa-rpc-node').registry;
 
 // Symbols
 const _sofaRegistry = Symbol.for('egg#sofaRegistry');
@@ -17,9 +16,12 @@ module.exports = {
   get sofaRegistry() {
     if (!this[_sofaRegistry]) {
       const options = this.config.sofaRpc.registry;
-      if (!options || !options.address) return null;
-      this[_sofaRegistry] = new ZookeeperRegistry(Object.assign({
+      if (!options) return null;
+
+      const registryClass = this.config.sofaRpc.registryClass;
+      this[_sofaRegistry] = new registryClass(Object.assign({
         logger: this.coreLogger,
+        cluster: this.cluster,
       }, options));
       this[_sofaRegistry].on('error', err => { this.coreLogger.error(err); });
       this.beforeClose(async () => {

--- a/config/config.default.js
+++ b/config/config.default.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const antpb = require('antpb');
 const protocol = require('sofa-bolt-node');
+const { ZookeeperRegistry } = require('sofa-rpc-node').registry;
 
 module.exports = appInfo => {
 
@@ -16,9 +17,8 @@ module.exports = appInfo => {
 
   return {
     sofaRpc: {
-      registry: {
-        // address: 'registry address',
-      },
+      registryClass: ZookeeperRegistry,
+      registry: null,
       client: {
         protocol,
         responseTimeout: 3000,

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const http = require('http');
-const path = require('path');
 const is = require('is-type-of');
 const assert = require('assert');
 const cluster = require('cluster');
@@ -49,11 +48,7 @@ class EggRpcServer extends RpcServer {
   load() {
     const { app } = this;
     const { namespace } = app.config.sofaRpc.server;
-    const paths = app.loader.getLoadUnits().map(unit => path.join(unit.path, 'app/rpc'));
-    app.loader.loadToApp(paths, 'rpcServices', {
-      call: true,
-      caseStyle: 'camel', // 首字母不变
-    });
+
     // load apiMeta
     for (const name in app.rpcServices) {
       let delegate = app.rpcServices[name];

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "app",
     "lib",
     "config",
-    "app.js"
+    "app.js",
+    "agent.js"
   ],
   "eggPlugin": {
     "name": "sofaRpc"
@@ -41,17 +42,17 @@
     "antpb": "^1.0.0",
     "is-type-of": "^1.2.1",
     "sofa-bolt-node": "^1.0.2",
-    "sofa-rpc-node": "^1.3.0"
+    "sofa-rpc-node": "^1.3.1"
   },
   "devDependencies": {
     "autod": "^3.0.1",
     "autod-egg": "^1.1.0",
     "contributors": "^0.5.1",
-    "egg": "^2.11.2",
+    "egg": "^2.12.0",
     "egg-bin": "^4.9.0",
     "egg-mock": "^3.20.1",
     "egg-rpc-generator": "^1.0.0",
-    "eslint": "^5.6.1",
+    "eslint": "^5.7.0",
     "eslint-config-egg": "^7.1.0",
     "mz-modules": "^2.1.0",
     "urllib": "^2.28.1"

--- a/test/custom_registry.test.js
+++ b/test/custom_registry.test.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const path = require('path');
+const mm = require('egg-mock');
+const assert = require('assert');
+const sleep = require('mz-modules/sleep');
+const rimraf = require('mz-modules/rimraf');
+
+describe('test/custom_registry.test.js', () => {
+
+  async function cleanDir() {
+    await Promise.all([
+      rimraf(path.join(__dirname, 'fixtures/apps/custom-registry/app/proxy')),
+      rimraf(path.join(__dirname, 'fixtures/apps/custom-registry/logs')),
+      rimraf(path.join(__dirname, 'fixtures/apps/custom-registry/run')),
+    ]);
+  }
+
+  let app;
+  before(async function() {
+    app = mm.app({
+      baseDir: 'apps/custom-registry',
+    });
+    await app.ready();
+    await sleep(1000);
+  });
+  after(async function() {
+    await app.close();
+    await cleanDir();
+  });
+
+  it('should invoke ok', async function() {
+    const ctx = app.createAnonymousContext();
+    const res = await ctx.proxy.protoService.echoObj({
+      name: 'gxcsoccer',
+      group: 'B',
+    });
+    console.log(res);
+    assert.deepEqual(res, {
+      code: 200,
+      message: 'hello gxcsoccer from Node.js',
+    });
+  });
+
+  it('should app.rpcRequest ok', done => {
+    app.rpcRequest('com.alipay.sofa.rpc.test.ProtoService')
+      .invoke('echoObj')
+      .send([{
+        name: 'gxcsoccer',
+        group: 'B',
+      }])
+      .expect({
+        code: 200,
+        message: 'hello gxcsoccer from Node.js',
+      }, done);
+  });
+});

--- a/test/fixtures/apps/custom-registry/app/router.js
+++ b/test/fixtures/apps/custom-registry/app/router.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = app => {
+  app.get('/', async function(ctx) {
+    ctx.body = await ctx.proxy.protoService.echoObj({
+      name: 'zongyu',
+      group: 'B',
+    });
+  });
+};

--- a/test/fixtures/apps/custom-registry/app/rpc/ProtoService.js
+++ b/test/fixtures/apps/custom-registry/app/rpc/ProtoService.js
@@ -1,0 +1,12 @@
+'use strict';
+
+exports.echoObj = async function(req) {
+  return {
+    code: 200,
+    message: 'hello ' + req.name + ' from Node.js',
+  };
+};
+
+exports.interfaceName = 'com.alipay.sofa.rpc.test.ProtoService';
+exports.version = '1.0';
+exports.group = 'SOFA';

--- a/test/fixtures/apps/custom-registry/config/config.default.js
+++ b/test/fixtures/apps/custom-registry/config/config.default.js
@@ -1,0 +1,8 @@
+'use strict';
+
+exports.sofaRpc = {
+  registryClass: require('../lib/registry'),
+  registry: {},
+};
+
+exports.keys = '123456';

--- a/test/fixtures/apps/custom-registry/config/plugin.js
+++ b/test/fixtures/apps/custom-registry/config/plugin.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const path = require('path');
+
+exports.sofaRpc = {
+  enable: true,
+  path: path.join(__dirname, '../../../../../'),
+};

--- a/test/fixtures/apps/custom-registry/config/proxy.js
+++ b/test/fixtures/apps/custom-registry/config/proxy.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = {
+  services: [{
+    appName: 'sofarpc',
+    api: {
+      ProtoService: 'com.alipay.sofa.rpc.test.ProtoService',
+    },
+  }],
+};

--- a/test/fixtures/apps/custom-registry/lib/client.js
+++ b/test/fixtures/apps/custom-registry/lib/client.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const Base = require('sdk-base');
+
+class SimpleRegistry extends Base {
+  constructor(options) {
+    super(options);
+    this.ready(true);
+  }
+
+  async register() {}
+
+  async unRegister() {}
+
+  subscribe(config, listener) {
+    setImmediate(() => {
+      listener([
+        'bolt://127.0.0.1:12200',
+      ]);
+    });
+  }
+
+  unSubscribe() {}
+
+  close() {
+    return Promise.resolve()
+  }
+}
+
+module.exports = SimpleRegistry;

--- a/test/fixtures/apps/custom-registry/lib/registry.js
+++ b/test/fixtures/apps/custom-registry/lib/registry.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const RegistryBase = require('sofa-rpc-node/lib/registry/base');
+const DataClient = require('./client');
+
+class CustomeRegistry extends RegistryBase {
+  get DataClient() {
+    return DataClient;
+  }
+}
+
+module.exports = CustomeRegistry

--- a/test/fixtures/apps/custom-registry/package.json
+++ b/test/fixtures/apps/custom-registry/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "custom-registry"
+}

--- a/test/fixtures/apps/custom-registry/proto/ProtoService.proto
+++ b/test/fixtures/apps/custom-registry/proto/ProtoService.proto
@@ -1,0 +1,25 @@
+syntax = "proto3";
+
+package com.alipay.sofa.rpc.test;
+
+// 可选
+option java_multiple_files = false;
+
+service ProtoService {
+  rpc echoObj (EchoRequest) returns (EchoResponse) {}
+}
+
+message EchoRequest {
+  string name = 1;
+  Group group = 2;
+}
+
+message EchoResponse {
+  int32 code = 1;
+  string message = 2;
+}
+
+enum Group {
+  A = 0;
+  B = 1;
+}

--- a/test/init.sh
+++ b/test/init.sh
@@ -5,7 +5,7 @@ GEN=${PWD}/node_modules/.bin/egg-rpc-generator
 # test dir
 
 DIR=${PWD}/test/fixtures/apps
-NAMES="sofarpc hardload"
+NAMES="sofarpc hardload custom-registry"
 
 for NAME in $NAMES
 do


### PR DESCRIPTION
优化了自定义 sofaRegistry 方式

## 开发自定义 Registry

自定义 Registry 需要实现下面一些接口

```js
// simple_registry.js
'use strict';

const Base = require('sdk-base');

class SimpleRegistry extends Base {
  constructor(options) {
    super(options);
    this.ready(true);
  }

  async register(config) { ... }

  async unRegister(config) { ... }

  subscribe(config, listener) { ... }

  unSubscribe(config, listener) { ... }

  close() { ... }
}

module.exports = SimpleRegistry;
```

然后用 `cluster-client` 封装起来

```js
'use strict';

const RegistryBase = require('sofa-rpc-node/lib/registry/base');
const DataClient = require('./simple_registry');

class ClusterRegistry extends RegistryBase {
  get DataClient() {
    return DataClient;
  }
}

module.exports = ClusterRegistry
```

## 覆盖默认的 Registry

```js
exports.sofaRpc = {
  registryClass: require('your-registry'),
  registry: {
    // 这里可以配置自定义的配置，这个节点不能为 null
  },
};
```

## 例子

https://github.com/eggjs/egg-sofa-rpc/tree/72709adbb81645b412e6fb39a7c2c697f9c6c894/test/fixtures/apps/custom-registry